### PR TITLE
Fix nuget authors

### DIFF
--- a/src/Homely.AspNetCore.WebApi.Template.nuspec
+++ b/src/Homely.AspNetCore.WebApi.Template.nuspec
@@ -6,7 +6,7 @@
     <description>
       Creates an opinionated ASP.NET Core Web API template.
     </description>
-    <authors>Homely's groovy developers!</authors>
+    <authors>Homely</authors>
     <language>en-AU</language>
     <iconUrl>http://i.imgur.com/NiTIb6V.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/Homely.AspNetCore.WebApi.Template.nuspec
+++ b/src/Homely.AspNetCore.WebApi.Template.nuspec
@@ -8,6 +8,8 @@
     </description>
     <authors>Homely's groovy developers!</authors>
     <language>en-AU</language>
+    <iconUrl>http://i.imgur.com/NiTIb6V.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectUrl>https://github.com/Homely/Homely.AspNetCore.WebApi.Template</projectUrl>
     <licenseUrl>https://github.com/Homely/Homely.AspNetCore.WebApi.Template/blob/master/LICENSE.txt</licenseUrl>
     <copyright>2018</copyright>

--- a/src/content/Homely.AspNetCore.WebApi.Template.csproj
+++ b/src/content/Homely.AspNetCore.WebApi.Template.csproj
@@ -5,18 +5,12 @@
     <LangVersion>latest</LangVersion>
     <PackageId>Homely.AspNetCore.WebApi.Template</PackageId>
     <Version>0.0.0</Version>
-    <Authors>Homely's developers</Authors>
-    <Company>Homely</Company>
-    <Product>Homely - ASPNet Core Web API Template</Product>
-    <Description>An opinionated ASPNet Core Web API template to help reduce the ceremony required in starting a new 'REST' like web application.</Description>
-    <Copyright>2018</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="2.1.1" />
     <PackageReference Include="Homely.AspNetCore.Hosting.CoreApp" Version="1.0.0" />
-    <PackageReference Include="Homely.AspNetCore.Mvc.Helpers" Version="5.0.0-dev" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="5.1.0" />
+    <PackageReference Include="Homely.AspNetCore.Mvc.Helpers" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.20.1" />
@@ -28,7 +22,6 @@
 
   <ItemGroup>
     <Folder Include="Configuration\" />
-    <Folder Include="Features\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet.org can auto link to an existing account if the `authors` value matches a nuget-org-user.